### PR TITLE
connect posts API to DDB helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,16 @@ You can input certain params to tell the script how to generate your package. It
 - Create .env on build, inject params based on input
 - Allow input for AWS region
 - Allow input for alternative post/object-types aside from Users and Posts and generate CRUD methods from them
+- Allow input for alternative DDB table names or prefixes
+
+> Alternative recommended
+> Use an Integrated Development Environment (IDE) which supports the AWS Toolkit enabling authentication through IAM Identity Center.
 
 ## Developing locally
 
 Run `yarn install` to get the dependencies installed.
+
+You need an AWS account with a table named "Users" and a table named "Posts".
 
 To run the development server:
 

--- a/helpers/aws.ts
+++ b/helpers/aws.ts
@@ -6,6 +6,7 @@ import {
   GetCommand,
   ScanCommand,
 } from '@aws-sdk/lib-dynamodb';
+import { randomUUID } from 'crypto';
 import { Item } from '../types/item';
 
 // AWS setup
@@ -29,7 +30,6 @@ const client = new DynamoDBClient({
 
 const ddbDocClient = DynamoDBDocumentClient.from(client);
 
-// the Item type will change based on the input!
 /**
  * Create Item helper wrapper
  * @param item item to put into the database
@@ -39,9 +39,13 @@ export async function createItem<T extends Item>(
   tableName: string,
   item: T
 ): Promise<void> {
+  const newId = randomUUID();
   const params = {
     TableName: tableName,
-    Item: item,
+    Item: {
+      ...item,
+      id: newId,
+    },
   };
 
   const command = new PutCommand(params);

--- a/pages/api/posts/[id].ts
+++ b/pages/api/posts/[id].ts
@@ -1,18 +1,42 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { PostData } from '../../../types/post';
 import { ResponseData } from '../../../types/responseData';
-import { fakePostsForNow } from '.';
+import { getItem, updateItemById } from '../../../helpers/aws';
+import { POSTS_TABLE } from '.';
 
 // TODO: change this to use the generic helpers when they exist
-export default function handler(
+export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<PostData | ResponseData>
 ) {
-  const {
-    query: { id },
-  } = req;
+  // if id is in fact an array dont support it for now.
+  // just pull the first id from the array.
+  const id = Array.isArray(req.query.id) ? req.query.id[0] : req.query.id;
 
-  const post = fakePostsForNow.find((post) => post.id === id);
+  if (!id) {
+    return res.status(422).json({
+      status: 422,
+      message: 'That aint right.',
+    });
+  }
+
+  switch (req.method) {
+    case 'PUT':
+      const { updateFields } = req.body;
+      await updateItemById(POSTS_TABLE, id, updateFields);
+      res.status(204).end();
+      break;
+    case 'GET':
+      const post = await getItem('id', id, POSTS_TABLE);
+      res.status(200).json(post as PostData);
+      break;
+    default:
+      res.setHeader('Allow', ['GET', 'PUT']);
+      res.status(405).end('Method Not Allowed');
+      break;
+  }
+
+  const post = await getItem('id', id, POSTS_TABLE);
   if (!post) {
     return res.status(404).json({
       status: 404,
@@ -20,5 +44,5 @@ export default function handler(
     });
   }
 
-  res.json({ ...post });
+  res.status(200).json(post as PostData);
 }

--- a/pages/api/posts/index.ts
+++ b/pages/api/posts/index.ts
@@ -1,44 +1,25 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { PostData } from '../../../types/post';
 import { ResponseData } from '../../../types/responseData';
+import { createItem, getAllItems } from '../../../helpers/aws';
 
-export const fakePostsForNow = [
-  {
-    id: '12345',
-    uri: 'post-url-12345',
-    content: {
-      titleText: 'First Post',
-      bodyText: 'This is a part of a post. It is the first post!',
-    },
-  },
-  {
-    id: '98765',
-    uri: 'post-url-98765',
-    content: {
-      titleText: 'Posty Post',
-      bodyText: 'This is a posty of a post.',
-    },
-  },
-];
+export const POSTS_TABLE = 'Posts';
 
 // consider using Edge api routes instead. https://nextjs.org/docs/api-routes/edge-api-routes
-export default function handler(
+export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<PostData | PostData[] | ResponseData>
 ) {
   // These are all default cases
   switch (req.method) {
     case 'POST':
-      // TODO: call handleCreatePost method
-      res.status(200).json(fakePostsForNow[1]);
-      break;
-    case 'PUT':
-      // TODO: call handleEditPost method
-      res.status(200).json(fakePostsForNow[0]);
+      const newPost = req.body;
+      await createItem(POSTS_TABLE, newPost);
+      res.status(200).json(newPost);
       break;
     case 'GET':
-      // TODO: call handleListPosts
-      res.status(200).json(fakePostsForNow);
+      const listOfPosts = await getAllItems(POSTS_TABLE);
+      res.status(200).json(listOfPosts as PostData[]);
       break;
     default:
       res.setHeader('Allow', ['GET', 'POST', 'PUT']);

--- a/types/item.ts
+++ b/types/item.ts
@@ -1,0 +1,5 @@
+export interface Item {
+  id: string;
+  uri?: string;
+  displayName?: string;
+}

--- a/types/post.ts
+++ b/types/post.ts
@@ -1,3 +1,5 @@
+import { Item } from './item';
+
 export interface PostContent {
   titleText?: string;
   bodyText?: string; // this is a simple string of the body
@@ -7,8 +9,9 @@ export interface PostContent {
   bodyRichContent?: string; // this is a string of HTML markup for the body. it can be used in place of simple text.
 }
 
-export type PostData = {
+export interface PostData extends Item {
   content: PostContent;
   id: string;
+  displayName?: string;
   uri?: string; // this is optional for a post that is newly created and hasnt autosaved yet
-};
+}


### PR DESCRIPTION
good milestone for PR number 10 ill say

- posts api is now connected to DDB helpers
- ddb helpers were made more generic to handle any superset of "item" type
- generic item type made
- posts inherits from item type
- posts api has methods: create, list all, get by id, update by id 

build works, dev server works, but have not tested against ddb yet since there's no 'create post' yet and i didnt want to manually create test data