### PR TITLE
make generic crud next api handlers

### DIFF
--- a/helpers/crudHandler.ts
+++ b/helpers/crudHandler.ts
@@ -1,0 +1,42 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import {
+  createItem,
+  updateItemById,
+  getItem,
+  getAllItems,
+} from '../helpers/aws';
+import { Item } from '../types/item';
+import { ResponseData } from '../types/responseData';
+
+// Define table names as constants
+const USERS_TABLE = 'YourUsersTableName';
+const POSTS_TABLE = 'YourPostsTableName';
+
+/**
+ * generic handler function to handle crud methods when no ID is passed as input.
+ * methods include create and listAllItems
+ * @param req
+ * @param res
+ * @typeParam ItemType - the type passed when the function is called, must extend Item
+ */
+export default async function crudHandler<ItemType extends Item>(
+  req: NextApiRequest,
+  res: NextApiResponse<ItemType | ItemType[] | ResponseData>,
+  tableName: string
+) {
+  switch (req.method) {
+    case 'POST':
+      const newItem = req.body;
+      await createItem(tableName, newItem);
+      res.status(200).json(newItem);
+      break;
+    case 'GET':
+      const listOfItems = await getAllItems(tableName);
+      res.status(200).json(listOfItems as ItemType[]);
+      break;
+    default:
+      res.setHeader('Allow', ['GET', 'POST', 'PUT']);
+      res.status(405).end('Method Not Allowed');
+      break;
+  }
+}

--- a/helpers/crudHandler.ts
+++ b/helpers/crudHandler.ts
@@ -1,16 +1,7 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import {
-  createItem,
-  updateItemById,
-  getItem,
-  getAllItems,
-} from '../helpers/aws';
+import { createItem, getAllItems } from '../helpers/aws';
 import { Item } from '../types/item';
 import { ResponseData } from '../types/responseData';
-
-// Define table names as constants
-const USERS_TABLE = 'YourUsersTableName';
-const POSTS_TABLE = 'YourPostsTableName';
 
 /**
  * generic handler function to handle crud methods when no ID is passed as input.

--- a/helpers/crudHandlerWithIdParam.ts
+++ b/helpers/crudHandlerWithIdParam.ts
@@ -1,0 +1,43 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { Item } from '../types/item';
+import { ResponseData } from '../types/responseData';
+import { getItem, updateItemById } from '../helpers/aws';
+
+export default async function crudHandlerWithIdParam<ItemType extends Item>(
+  req: NextApiRequest,
+  res: NextApiResponse<ItemType | ResponseData>,
+  tableName: string
+) {
+  // if id is in fact an array dont support it for now.
+  // just pull the first id from the array.
+  const id = Array.isArray(req.query.id) ? req.query.id[0] : req.query.id;
+
+  if (!id) {
+    return res.status(422).json({
+      status: 422,
+      message: 'That aint right.',
+    });
+  }
+
+  switch (req.method) {
+    case 'PUT':
+      const { updateFields } = req.body;
+      await updateItemById(tableName, id, updateFields);
+      res.status(204).end();
+      break;
+    case 'GET':
+      const item = await getItem('id', id, tableName);
+      if (!item) {
+        return res.status(404).json({
+          status: 404,
+          message: 'Not Found.',
+        });
+      }
+      res.status(200).json(item as ItemType);
+      break;
+    default:
+      res.setHeader('Allow', ['GET', 'PUT']);
+      res.status(405).end('Method Not Allowed');
+      break;
+  }
+}

--- a/helpers/crudHandlerWithIdParam.ts
+++ b/helpers/crudHandlerWithIdParam.ts
@@ -3,6 +3,7 @@ import { Item } from '../types/item';
 import { ResponseData } from '../types/responseData';
 import { getItem, updateItemById } from '../helpers/aws';
 
+// crud handler which is used for [id] route
 export default async function crudHandlerWithIdParam<ItemType extends Item>(
   req: NextApiRequest,
   res: NextApiResponse<ItemType | ResponseData>,

--- a/pages/api/posts/[id].ts
+++ b/pages/api/posts/[id].ts
@@ -1,47 +1,12 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { PostData } from '../../../types/post';
 import { ResponseData } from '../../../types/responseData';
-import { getItem, updateItemById } from '../../../helpers/aws';
 import { POSTS_TABLE } from '.';
+import crudHandlerWithIdParam from '../../../helpers/crudHandlerWithIdParam';
 
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<PostData | ResponseData>
 ) {
-  // if id is in fact an array dont support it for now.
-  // just pull the first id from the array.
-  const id = Array.isArray(req.query.id) ? req.query.id[0] : req.query.id;
-
-  if (!id) {
-    return res.status(422).json({
-      status: 422,
-      message: 'That aint right.',
-    });
-  }
-
-  switch (req.method) {
-    case 'PUT':
-      const { updateFields } = req.body;
-      await updateItemById(POSTS_TABLE, id, updateFields);
-      res.status(204).end();
-      break;
-    case 'GET':
-      const post = await getItem('id', id, POSTS_TABLE);
-      res.status(200).json(post as PostData);
-      break;
-    default:
-      res.setHeader('Allow', ['GET', 'PUT']);
-      res.status(405).end('Method Not Allowed');
-      break;
-  }
-
-  const post = await getItem('id', id, POSTS_TABLE);
-  if (!post) {
-    return res.status(404).json({
-      status: 404,
-      message: 'Not Found.',
-    });
-  }
-
-  res.status(200).json(post as PostData);
+  return crudHandlerWithIdParam<PostData>(req, res, POSTS_TABLE);
 }

--- a/pages/api/posts/index.ts
+++ b/pages/api/posts/index.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { PostData } from '../../../types/post';
 import { ResponseData } from '../../../types/responseData';
-import { createItem, getAllItems } from '../../../helpers/aws';
+import crudHandler from '../../../helpers/crudHandler';
 
 export const POSTS_TABLE = 'Posts';
 
@@ -10,19 +10,5 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<PostData | PostData[] | ResponseData>
 ) {
-  switch (req.method) {
-    case 'POST':
-      const newPost = req.body;
-      await createItem(POSTS_TABLE, newPost);
-      res.status(200).json(newPost);
-      break;
-    case 'GET':
-      const listOfPosts = await getAllItems(POSTS_TABLE);
-      res.status(200).json(listOfPosts as PostData[]);
-      break;
-    default:
-      res.setHeader('Allow', ['GET', 'POST', 'PUT']);
-      res.status(405).end('Method Not Allowed');
-      break;
-  }
+  return crudHandler<PostData>(req, res, POSTS_TABLE);
 }

--- a/pages/api/users/[id].ts
+++ b/pages/api/users/[id].ts
@@ -1,47 +1,12 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { User } from '../../../types/user';
 import { ResponseData } from '../../../types/responseData';
-import { getItem, updateItemById } from '../../../helpers/aws';
 import { USERS_TABLE } from '.';
+import crudHandlerWithIdParam from '../../../helpers/crudHandlerWithIdParam';
 
 export default async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<User | User[] | ResponseData>
+  res: NextApiResponse<User | ResponseData>
 ) {
-  // if id is in fact an array dont support it for now.
-  // just pull the first id from the array.
-  const id = Array.isArray(req.query.id) ? req.query.id[0] : req.query.id;
-
-  if (!id) {
-    return res.status(422).json({
-      status: 422,
-      message: 'That aint right.',
-    });
-  }
-
-  switch (req.method) {
-    case 'PUT':
-      const { updateFields } = req.body;
-      await updateItemById(USERS_TABLE, id, updateFields);
-      res.status(204).end();
-      break;
-    case 'GET':
-      const post = await getItem('id', id, USERS_TABLE);
-      res.status(200).json(post as User);
-      break;
-    default:
-      res.setHeader('Allow', ['GET', 'PUT']);
-      res.status(405).end('Method Not Allowed');
-      break;
-  }
-
-  const post = await getItem('id', id, USERS_TABLE);
-  if (!post) {
-    return res.status(404).json({
-      status: 404,
-      message: 'Not Found.',
-    });
-  }
-
-  res.status(200).json(post as User);
+  return crudHandlerWithIdParam<User>(req, res, USERS_TABLE);
 }

--- a/pages/api/users/index.ts
+++ b/pages/api/users/index.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { ResponseData } from '../../../types/responseData';
 import { User } from '../../../types/user';
-import { createItem, getAllItems } from '../../../helpers/aws';
+import crudHandler from '../../../helpers/crudHandler';
 
 export const USERS_TABLE = 'Users';
 
@@ -9,21 +9,5 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<User | User[] | ResponseData>
 ) {
-  switch (req.method) {
-    case 'POST':
-      // create a new user
-      const newPost = req.body;
-      await createItem(USERS_TABLE, newPost);
-      res.status(200).json(newPost);
-      break;
-    case 'GET':
-      // TODO: get list of users by some criteria, for example a hi scores page.
-      const listOfUsers = await getAllItems(USERS_TABLE);
-      res.status(200).json(listOfUsers as User[]);
-      break;
-    default:
-      res.setHeader('Allow', ['GET', 'POST']);
-      res.status(405).end('Method Not Allowed');
-      break;
-  }
+  return crudHandler<User>(req, res, USERS_TABLE);
 }


### PR DESCRIPTION
look at all the wonderful red

- created handler for index handler with no params passed, called crudHandler
- created crudHandlerWithIdParam as well for when id is passed in the url
  - this could be made generic to pass id or slug or any other sort of lookup which would get passed in a url param
- converted users and posts apis to use the handler helpers

it is always a good pr when there is more deleted lines than added.