### PR TITLE
add setup scripts and instructions for running them 🅱️

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "extends": ["next", "prettier"],
   "rules": {
-    "quotes": ["error", "single"]
+    "quotes": ["error", "single", { "allowTemplateLiterals": true }]
   }
 }

--- a/README.md
+++ b/README.md
@@ -6,7 +6,21 @@ You can input certain params to tell the script how to generate your package. It
 
 ## How to use
 
+There are two ways to use the posting platform 1. use the npm module or 2. clone this package
+
 Requirements include yarn and node. You need at least node 18.
+
+### Using the npm module
+
+Create your new app by just passing a name. Be sure to run this from the directory where you hold all your projects.
+
+```
+npx the-posting-platform my-app-name
+```
+
+This will create your new app in a subdirectory from your current directory. It will then copy the needed boilerplate files over and prompt you for some inputs on what you wanna name this app and stuff.
+
+### Cloning this package
 
 You can run these scripts to get all the functionality of this platform. For now, you pull this repo and run its scripts, which clone necessary boilerplate to your package. Then, you run the platform-setup script to customize your app.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,48 @@ Create your own platform for user generated content by using this package. You c
 
 You can input certain params to tell the script how to generate your package. It will randomly generate some configs for you, so your site is fairly unique every time you run the generation script. You can input some params to describe how your platform should look, and it will set a few different things accordingly.
 
+## How to use
+
+Requirements include yarn and node. You need at least node 18.
+
+You can run these scripts to get all the functionality of this platform. For now, you pull this repo and run its scripts, which clone necessary boilerplate to your package. Then, you run the platform-setup script to customize your app.
+
+You have the freedom of creating your own next app, rather than this platform dictating some out of date version.
+
+```
+npx create-next-app my-new-app --typescript
+cd my-new-app
+rm -rf pages
+git clone https://github.com/ianmiller347/the-posting-platform.git
+cd the-posting-platform
+yarn run setup-script
+```
+
+Now your necessary files have been copied over. Next let's install dependencies.
+
+```
+# go back to your app root
+cd ../
+# run the install script from your app root
+node the-posting-platform/installDependencies.js
+```
+
+Great now let's setup your platform
+
+```
+node platformSetup.js
+```
+
+Answer the questions to populate necessary variables to power your app.
+
+That's it!
+
+Now you can delete the posting platform directory
+
+```
+rm -rf the-posting-platform
+```
+
 ## Roadmap
 
 - Create .env on build, inject params based on input

--- a/components/Nav/Nav.tsx
+++ b/components/Nav/Nav.tsx
@@ -19,6 +19,9 @@ export default function Nav() {
         <li className={cx('nav__list-item')}>
           <Link href="/users">Users</Link>
         </li>
+        <li className={cx('nav__list-item')}>
+          <Link href="/profile">Profile</Link>
+        </li>
       </ul>
     </nav>
   );

--- a/components/Page/Page.tsx
+++ b/components/Page/Page.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames/bind';
 import styles from './Page.module.css';
 import Footer from '../Footer';
 import Header from '../Header';
+import platformConfig from '../../platform.config';
 
 const cx = classNames.bind(styles);
 
@@ -13,14 +14,10 @@ interface PageProps {
   title?: string;
 }
 
-const siteTitle = 'The Posting Platform';
-const siteDescription =
-  'Post things on the posting platform. It is the platform for posting. Check out the posts on the posting platform.';
-
 /**
  * Page holds the layout and contents of a page on the application.
  * It holds page data like the title, description, and body contents
- * It holds the layout of hte page as well.
+ * It holds the layout of the page as well.
  *
  * Head is the html head attribute that gets populated for metadata
  * Header is the header of the page
@@ -29,27 +26,32 @@ const siteDescription =
  *
  * @returns Page
  */
-const Page = ({
-  children,
-  description = siteDescription,
-  title = siteTitle,
-}: PageProps) => (
-  <div className={cx('container', 'page')}>
-    <Head>
-      <title>{title === siteTitle ? title : `${title} | ${siteTitle}`}</title>
-      <meta name="description" content={description} />
-      <link rel="icon" href="/favicon.ico" />
-    </Head>
+const Page = ({ children, description, title }: PageProps) => {
+  const { platformName, platformDescription } = platformConfig;
+  const pageTitle = title ?? platformName;
+  const pageDescription = description ?? platformDescription;
+  return (
+    <div className={cx('container', 'page')}>
+      <Head>
+        <title>
+          {platformName === pageTitle
+            ? pageTitle
+            : `${pageTitle} | ${platformName}`}
+        </title>
+        <meta name="description" content={pageDescription} />
+        <link rel="icon" href="/favicon.ico" />
+      </Head>
 
-    <Header />
+      <Header />
 
-    <main className={cx('main')}>
-      <h1 className={cx('page__title')}>{title}</h1>
-      {children}
-    </main>
+      <main className={cx('main')}>
+        <h1 className={cx('page__title')}>{pageTitle}</h1>
+        {children}
+      </main>
 
-    <Footer />
-  </div>
-);
+      <Footer />
+    </div>
+  );
+};
 
 export default Page;

--- a/components/UsersList/UsersList.tsx
+++ b/components/UsersList/UsersList.tsx
@@ -1,0 +1,33 @@
+import { User } from '../../types/user';
+import { useGetUsersQuery } from '../../state/user';
+import SkeletonLoaderBars from '../SkeletonLoaderBars';
+
+const UsersList = () => {
+  const { data: users, error, isLoading } = useGetUsersQuery('');
+
+  return (
+    <div className="users-list">
+      {isLoading && <SkeletonLoaderBars />}
+      <ul>
+        {users?.map((user: User) => (
+          <li
+            key={user.id}
+            className="border rounded-lg mb-4 p-4 dark-mode dark:bg-slate-800"
+          >
+            <article className="">
+              <h3 className="text-xl font-medium dark:text-white">
+                {user.displayName}
+              </h3>
+              <p className="dark:text-white">{user.content.description}</p>
+            </article>
+          </li>
+        ))}
+      </ul>
+      {error && (
+        <div className="error">Sorry, there was an error loading users.</div>
+      )}
+    </div>
+  );
+};
+
+export default UsersList;

--- a/components/UsersList/index.ts
+++ b/components/UsersList/index.ts
@@ -1,0 +1,1 @@
+export { default } from './UsersList';

--- a/helpers/aws.ts
+++ b/helpers/aws.ts
@@ -10,8 +10,7 @@ import { randomUUID } from 'crypto';
 import { Item } from '../types/item';
 
 // AWS setup
-// TODO: change region to come from input.
-const REGION = 'us-east-1';
+const fallbackRegion = 'us-east-1';
 
 let accessKeyId = process.env.AWS_ACCESS_KEY_ID;
 let secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
@@ -21,7 +20,7 @@ if (!accessKeyId || !secretAccessKey) {
 }
 
 const client = new DynamoDBClient({
-  region: REGION,
+  region: process.env.AWS_REGION || fallbackRegion,
   credentials: {
     accessKeyId,
     secretAccessKey,

--- a/installDependencies.js
+++ b/installDependencies.js
@@ -1,0 +1,49 @@
+const fs = require('node:fs');
+const { execSync } = require('child_process');
+
+// Function to execute shell commands
+function executeCommand(command) {
+  try {
+    execSync(command, { stdio: 'inherit' });
+  } catch (error) {
+    console.error(`Error executing command: ${command}`);
+    process.exit(1);
+  }
+}
+
+// install dependencies.
+// Function to read dependencies from package.json
+function readDependenciesFromPackageJson(dependencyType = 'dependencies') {
+  // Read package.json file
+  const packageJson = fs.readFileSync('package.json', 'utf8');
+
+  // Parse package.json content to get dependencies
+  const dependencies = JSON.parse(packageJson)[dependencyType];
+
+  // Return an array of dependencies
+  return Object.keys(dependencies);
+}
+
+// Function to install dependencies using yarn
+function installDependencies(dependencies, isDevDeps = false) {
+  // Install dependencies using yarn
+  executeCommand(`yarn add ${isDevDeps ? '-D' : ''}${dependencies.join(' ')}`);
+}
+
+// Main function to copy dependencies from package.json and install them
+function copyAndInstallDependencies() {
+  // Read dependencies from package.json
+  const dependencies = readDependenciesFromPackageJson('dependencies');
+  const devDependencies = readDependenciesFromPackageJson('devDependencies');
+
+  // Install dependencies using yarn
+  installDependencies(dependencies, false);
+  installDependencies(devDependencies, true);
+
+  console.log(
+    'Dependencies and dev dependencies copied and installed successfully.'
+  );
+}
+
+// Execute the copy and install dependencies function
+copyAndInstallDependencies();

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "prepare": "husky install",
     "setup-script": "node setupScript.js"
   },
+  "bin": {
+    "create-posting-platform": "setupProject.js"
+  },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.254.0",
     "@aws-sdk/lib-dynamodb": "^3.254.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "format": "prettier --write . && yarn lint:fix",
     "lint": "next lint",
     "lint:fix": "next lint --fix",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "setup-script": "node setupScript.js"
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.254.0",

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -1,6 +1,8 @@
 import NextAuth from 'next-auth';
 // import EmailProvider from 'next-auth/providers/email';
+import GitHubProvider from 'next-auth/providers/github';
 
+// email providers supported https://community.nodemailer.com/2-0-0-beta/setup-smtp/well-known-services/
 const options = {
   providers: [
     // EmailProvider({
@@ -15,6 +17,10 @@ const options = {
     //   from: process.env.EMAIL_FROM,
     //   maxAge: 10 * 60,
     // }),
+    GitHubProvider({
+      clientId: process.env.GITHUB_ID || '',
+      clientSecret: process.env.GITHUB_SECRET || '',
+    }),
   ],
 };
 

--- a/pages/users/Users.tsx
+++ b/pages/users/Users.tsx
@@ -1,0 +1,15 @@
+import Page from '../../components/Page';
+import UsersList from '../../components/UsersList';
+
+export default function Users() {
+  return (
+    <Page title="Users" description="Users on the Posting Platform">
+      <>
+        <p className="mb-8">
+          Check out some of the users who are all from here
+        </p>
+        <UsersList />
+      </>
+    </Page>
+  );
+}

--- a/pages/users/index.ts
+++ b/pages/users/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Users';

--- a/platform-setup.sh
+++ b/platform-setup.sh
@@ -1,0 +1,28 @@
+# Platform setup if you prefer shell instead of node.js runtime
+read -p "What name do you want to use for your new app?" APP_NAME
+# Check if the .env file exists
+if [ -f .env ]; then
+    # Modify the existing .env file or create it if it doesn't exist
+    echo "APP_NAME=$APP_NAME" >> .env
+else
+    # Create a new .env file with the environmental variable
+    echo "APP_NAME=$APP_NAME" > .env
+fi
+read -p "Describe your app in 100 words or less." APP_DESCRIPTION
+read -p "Make up a one word descriptive name or adjective for your apps theme" APP_THEME
+
+# Email setup for auth
+read -p "What is your email server host?" EMAIL_SERVER_HOST
+read -p "What is your email server port?" EMAIL_SERVER_PORT
+read -p "What is your email server username?" EMAIL_SERVER_USER
+read -p "What is your email server password?" EMAIL_SERVER_PASSWORD
+read -p "What is the from address for your email server?" EMAIL_SERVER_FROM
+
+# AWS setup
+FOO="${AWS_REGION:-default}"
+read -p "What AWS region do you want to use? (Enter for default: us-east-1)" AWS_REGION
+# If the user didn't provide any input, set the default value
+AWS_REGION="${input:-us-east-1}"
+echo "AWS_REGION set to: $AWS_REGION"
+read -p "What is your AWS secret key?" AWS_SECRET_ACCESS_KEY
+read -p "What is your AWS access key id?" AWS_ACCESS_KEY_ID

--- a/platform.config.js
+++ b/platform.config.js
@@ -3,8 +3,11 @@
  * The theme can dictate how the pages will look.
  */
 const platformConfig = {
-  platformName: 'The Posting Platform',
-  platformTheme: 'posty',
+  platformName: process.env.APP_NAME || 'The Posting Platform',
+  platformDescription:
+    process.env.APP_DESCRIPTION ||
+    'Post things on the posting platform. It is the platform for posting. Check out the posts on the posting platform.',
+  platformTheme: process.env.APP_THEME || 'posty',
 };
 
 module.exports = platformConfig;

--- a/platformSetup.js
+++ b/platformSetup.js
@@ -1,0 +1,97 @@
+const fs = require('fs');
+const readline = require('readline');
+
+// Function to prompt user for input
+function prompt(question) {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      rl.close();
+      resolve(answer);
+    });
+  });
+}
+
+// Function to set or update environment variables in the .env file
+function setEnvVariable(key, value) {
+  // Check if the .env file exists
+  let envContent = '';
+  if (fs.existsSync('.env')) {
+    // Read existing .env file content
+    envContent = fs.readFileSync('.env', 'utf8');
+  }
+
+  // Update the content with the new or updated key-value pair
+  const regex = new RegExp(`^${key}=.*`, 'gm');
+  if (envContent.match(regex)) {
+    // If the key already exists, update its value
+    envContent = envContent.replace(regex, `${key}=${value}`);
+  } else {
+    // If the key doesn't exist, append it to the end of the file
+    envContent += `${key}=${value}\n`;
+  }
+
+  // Write the updated content back to the .env file
+  fs.writeFileSync('.env', envContent);
+}
+
+(async () => {
+  // Prompt user for app name
+  const appName = await prompt(
+    'What name do you want to use for your new app? '
+  );
+  setEnvVariable('APP_NAME', appName);
+
+  // Prompt user for app description
+  const appDescription = await prompt(
+    'Describe your app in 100 words or less: '
+  );
+  setEnvVariable('APP_DESCRIPTION', appDescription);
+
+  // Prompt user for app theme
+  const appTheme = await prompt(
+    `Make up a one-word descriptive name or adjective for your app's theme: `
+  );
+  setEnvVariable('APP_THEME', appTheme);
+
+  console.log('App setup complete, next lets setup AWS');
+
+  // Prompt user for AWS configuration
+  const awsRegion = await prompt(
+    'What AWS region do you want to use? (Enter for default: us-east-1) '
+  );
+  const awsRegionDefault = awsRegion || 'us-east-1'; // Default to us-east-1 if user doesn't input anything
+  setEnvVariable('AWS_REGION', awsRegionDefault);
+
+  const awsSecretAccessKey = await prompt('What is your AWS secret key? ');
+  setEnvVariable('AWS_SECRET_ACCESS_KEY', awsSecretAccessKey);
+
+  const awsAccessKeyId = await prompt('What is your AWS access key id? ');
+  setEnvVariable('AWS_ACCESS_KEY_ID', awsAccessKeyId);
+
+  console.log('Setup complete.');
+
+  // Prompt user for email server configuration
+  const emailServerHost = await prompt('What is your email server host? ');
+  setEnvVariable('EMAIL_SERVER_HOST', emailServerHost);
+
+  const emailServerPort = await prompt('What is your email server port? ');
+  setEnvVariable('EMAIL_SERVER_PORT', emailServerPort);
+
+  const emailServerUser = await prompt('What is your email server username? ');
+  setEnvVariable('EMAIL_SERVER_USER', emailServerUser);
+
+  const emailServerPassword = await prompt(
+    'What is your email server password? '
+  );
+  setEnvVariable('EMAIL_SERVER_PASSWORD', emailServerPassword);
+
+  const emailServerFrom = await prompt(
+    'What is the from address for your email server? '
+  );
+  setEnvVariable('EMAIL_SERVER_FROM', emailServerFrom);
+})();

--- a/platformSetup.js
+++ b/platformSetup.js
@@ -39,10 +39,10 @@ function setEnvVariable(key, value) {
   fs.writeFileSync('.env', envContent);
 }
 
-(async () => {
+async function setupPlatform() {
   // Prompt user for app name
   const appName = await prompt(
-    'What name do you want to use for your new app? '
+    'What name do you want to use for your new app? (App Name) '
   );
   setEnvVariable('APP_NAME', appName);
 
@@ -64,8 +64,9 @@ function setEnvVariable(key, value) {
   const awsRegion = await prompt(
     'What AWS region do you want to use? (Enter for default: us-east-1) '
   );
-  const awsRegionDefault = awsRegion || 'us-east-1'; // Default to us-east-1 if user doesn't input anything
-  setEnvVariable('AWS_REGION', awsRegionDefault);
+  // Default to us-east-1 if user doesn't input anything
+  const awsRegionDefault = 'us-east-1';
+  setEnvVariable('AWS_REGION', awsRegion || awsRegionDefault);
 
   const awsSecretAccessKey = await prompt('What is your AWS secret key? ');
   setEnvVariable('AWS_SECRET_ACCESS_KEY', awsSecretAccessKey);
@@ -94,4 +95,6 @@ function setEnvVariable(key, value) {
     'What is the from address for your email server? '
   );
   setEnvVariable('EMAIL_SERVER_FROM', emailServerFrom);
-})();
+}
+
+module.exports = setupPlatform;

--- a/setupProject.js
+++ b/setupProject.js
@@ -1,0 +1,65 @@
+const fs = require('fs-extra');
+const path = require('path');
+const { execSync } = require('child_process');
+const copyFoldersOver = require('./setupScript');
+const setupPlatform = require('./platformSetup');
+
+/**
+ * This file is for setting up a project when this package was installed as a global npm module
+ *
+ * npm install -g the-posting-platform
+ *
+ * Scripts currently offered:
+ *
+ * create-posting-platform
+ * cd my-projects
+ * create-posting-platform my-new-app
+ * currently it copies files into the users source code to replace their nextjs boilerplate
+ *
+ * it could act more like a library where it just exports modules used by another app
+ * but for now it provides a lot of source code for you. perhaps the --library option could be added.
+ *
+ */
+
+// Main function to set up the project
+async function setupProject() {
+  try {
+    // Get the directory where the script is being executed
+    const currentDirectory = process.cwd();
+
+    // Get the project name from command line arguments
+    const projectName = process.argv[2];
+
+    if (!projectName) {
+      console.error('Please provide a project name.');
+      return;
+    }
+
+    // Run create-next-app with the provided project name
+    const createNextApp = `npx create-next-app ${projectName} --typescript`;
+    execSync(createNextApp, { stdio: 'inherit' });
+
+    // now that we ran create next app, we want to modify the nextjs boilerplate
+    // and put our stuff in the new directory
+    const projectDirectory = path.join(currentDirectory, projectName);
+    // copy the folders and files into the newly created next app
+    await copyFoldersOver(projectDirectory);
+
+    // now make them change into the new directory
+    process.chdir(projectDirectory);
+
+    // next initialize husky, prettier, lint-staged
+    execSync('npx husky init', { stdio: 'inherit' });
+
+    console.log('Project creation complete. Now time for setup...');
+
+    await setupPlatform();
+
+    console.log('Platform setup complete.');
+  } catch (error) {
+    console.error('Error setting up project:', error);
+  }
+}
+
+// Call the setupProject function
+setupProject();

--- a/setupScript.js
+++ b/setupScript.js
@@ -1,0 +1,43 @@
+const fs = require('node:fs');
+
+/**
+ *
+ * This setup script clones all boilerplate to a parent project.
+ * It is to be run inside of a project that was just created.
+ * It means it must be run within a subfolder of the root project.
+ * if you're in parent-app, then you clone this repo and run this script.
+ *
+ * For example:
+ * create-next-app my-app
+ * cd my-app
+ * git clone https://github.com/ianmiller347/the-posting-platform.git
+ * cd the-posting-platform
+ * yarn run setup-script
+ *
+ * now, the parent application is where we want to copy folders to.
+ *
+ */
+
+// copy folders over
+fs.cpSync('helpers', '../helpers', { recursive: true });
+fs.cpSync('pages', '../pages', { recursive: true });
+fs.cpSync('hooks', '../hooks', { recursive: true });
+fs.cpSync('components', '../components', { recursive: true });
+
+// copy config files over
+// Array of files to copy
+const filesToCopy = [
+  'tsconfig.json',
+  '.prettierrc',
+  'tailwind.config.js',
+  '.lintstagedrc.js',
+  '.eslintrc.json',
+  'platform.config.js',
+];
+
+// Copy each file to the parent directory
+filesToCopy.forEach((file) => {
+  fs.copySync(file, `../${file}`);
+});
+
+console.log('Files copied successfully.');

--- a/setupScript.js
+++ b/setupScript.js
@@ -16,28 +16,72 @@ const fs = require('node:fs');
  *
  * now, the parent application is where we want to copy folders to.
  *
+ * the function is called when this file is called by node, but also exported
+ * so that other files can pass in pathPrefix if we create in subdirectory
+ * when global npm module is installed by a user
+ *
  */
 
-// copy folders over
-fs.cpSync('helpers', '../helpers', { recursive: true });
-fs.cpSync('pages', '../pages', { recursive: true });
-fs.cpSync('hooks', '../hooks', { recursive: true });
-fs.cpSync('components', '../components', { recursive: true });
+// Function to copy files from source directory to destination directory
+async function copyDirectories(directories, destinationPrefix) {
+  try {
+    for (const directory of directories) {
+      // const source = directory;
+      const source = path.resolve(__dirname, directory);
+      const destination = path.join(destinationPrefix, directory);
+      await fs.copy(source, destination, { recursive: true });
+      console.log(`Copied ${source} to ${destination}`);
+    }
+  } catch (error) {
+    console.error('Error copying directories:', error);
+  }
+}
 
-// copy config files over
-// Array of files to copy
-const filesToCopy = [
-  'tsconfig.json',
-  '.prettierrc',
-  'tailwind.config.js',
-  '.lintstagedrc.js',
-  '.eslintrc.json',
-  'platform.config.js',
-];
+// Define the source directory in your npm package containing the files to copy
+// const sourceDirectory = path.resolve(__dirname, 'source');
 
-// Copy each file to the parent directory
-filesToCopy.forEach((file) => {
-  fs.copySync(file, `../${file}`);
-});
+// Copy files from the source directory to the project directory
+// await copyFiles(sourceDirectory, projectDirectory);
 
-console.log('Files copied successfully.');
+// function to copy folders over
+const copyFoldersOver = async (
+  destinationPathPrefix = '..',
+  sourcePathPrefix = ''
+) => {
+  // copy the directories over first
+  const sourceDirectories = [
+    'components',
+    'helpers',
+    'hooks',
+    'pages',
+    'state',
+    'styles',
+    'types',
+  ];
+
+  await copyDirectories(sourceDirectories, destinationPathPrefix);
+
+  console.log('Folders copied successfully.');
+
+  // Next we will copy the config files that are in the current root over to the new project
+  // Array of files to copy
+  const filesToCopy = [
+    'tsconfig.json',
+    '.prettierrc',
+    'tailwind.config.js',
+    '.lintstagedrc.js',
+    '.eslintrc.json',
+    'platform.config.js',
+  ];
+
+  // Copy each file to the parent directory
+  filesToCopy.forEach((file) => {
+    fs.copySync(file, `${destinationPathPrefix}/${file}`);
+  });
+
+  console.log('All files copied successfully.');
+};
+
+copyFoldersOver();
+
+module.exports = copyFoldersOver;


### PR DESCRIPTION
- create setup scripts
- add instructions on how to run them
- create shell and node version for platform setup script, we could just remove the shell one but i had written it then converted it to node after and didnt delete it


open items/todo
- this could be cleaned up by making the user do fewer commands. we could add commands into the first script that the user creates instead of making them type the specific series of commands
- needs tests
- only supports create next app, we could make it support vite
- needs separated modules and published to npm so we can run fewer scripts